### PR TITLE
feat: use `unwrap` instead of `expect` when decrypting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,7 +377,7 @@ checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "staticrypt"
-version = "1.0.4"
+version = "1.1.0"
 dependencies = [
  "aes-gcm",
  "staticrypt_macros",
@@ -385,7 +385,7 @@ dependencies = [
 
 [[package]]
 name = "staticrypt_macros"
-version = "1.0.4"
+version = "1.1.0"
 dependencies = [
  "aes-gcm",
  "darling",
@@ -400,7 +400,7 @@ dependencies = [
 
 [[package]]
 name = "staticrypt_testbin"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "staticrypt",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "staticrypt"
-version = "1.0.4"
+version.workspace = true
 edition = "2024"
 license = "MIT"
 description = "Static encryption for string literals and binary data"
@@ -8,9 +8,12 @@ description = "Static encryption for string literals and binary data"
 [workspace]
 members = [".", "macros", "testbin"]
 
+[workspace.package]
+version = "1.1.0"
+
 [workspace.dependencies]
 aes-gcm = "0.10.3"
 
 [dependencies]
 aes-gcm.workspace = true
-staticrypt_macros = { version = "1.0.0", path = "macros" }
+staticrypt_macros = { version = "1.1.0", path = "macros" }

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "staticrypt_macros"
-version = "1.0.4"
+version.workspace = true
 edition = "2024"
 license = "MIT"
 description = "Macros for the `staticrypt` crate"

--- a/macros/src/literal.rs
+++ b/macros/src/literal.rs
@@ -36,7 +36,7 @@ pub fn sc(input: TokenStream) -> TokenStream {
             const ENCRYPTED: &[u8] = &#encrypted_literal;
             const NONCE: &[u8] = &#nonce_literal;
 
-            ::std::string::String::from_utf8(#crate_name::decrypt(ENCRYPTED, NONCE, crate::STATICRYPT_ENCRYPT_KEY)).expect("Failed to parse contents to string")
+            ::std::string::String::from_utf8(#crate_name::decrypt(ENCRYPTED, NONCE, crate::STATICRYPT_ENCRYPT_KEY)).unwrap()
         }
     }.into()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,9 +126,7 @@ pub fn decrypt(input: &[u8], nonce: &[u8], key: &[u8]) -> Vec<u8> {
     let key = Key::<Aes256Gcm>::from_slice(key);
     let cipher = Aes256Gcm::new(key);
 
-    cipher
-        .decrypt(nonce.into(), input)
-        .expect("Failed to decrypt contents")
+    cipher.decrypt(nonce.into(), input).unwrap()
 }
 
 #[cfg(test)]

--- a/testbin/Cargo.toml
+++ b/testbin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "staticrypt_testbin"
-version = "1.0.0"
+version.workspace = true
 edition = "2024"
 publish = false
 


### PR DESCRIPTION
This makes static analysis more difficult, by not allowing attackers to search for references to the error message as easily.